### PR TITLE
feat: resorted to use reflection to detect better protocolschedule

### DIFF
--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/extensions/ReflectExt.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/extensions/ReflectExt.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 41North.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.exflo.ingestion.extensions
+
+fun <T : Any> assertNotNull(
+    actual: T?,
+    message: String = "null found"
+): T {
+    assert(actual != null) { message }
+    return actual!!
+}
+
+inline fun <reified T : Any> reflektField(entity: Any, fieldName: String): T {
+    val field = assertNotNull(entity::class.java.declaredFields.find { it.name == fieldName })
+    if (!field.isAccessible) field.isAccessible = true
+    return field.get(entity) as T
+}
+
+inline fun <reified T : Any> reflektMethod(entity: Any, methodName: String, vararg args: Any?): T {
+    val method = assertNotNull(entity::class.java.declaredMethods.find { it.name == methodName })
+    if (!method.isAccessible) method.isAccessible = true
+    return method.invoke(entity, args) as T
+}
+
+inline fun <reified T : Any> reflektMethod(entity: Any? = null, clazz: Class<*>, methodName: String, vararg args: Any?): T {
+    val method = assertNotNull(clazz.declaredMethods.find { it.name == methodName })
+    if (!method.isAccessible) method.isAccessible = true
+    return method.invoke(entity, args) as T
+}

--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/tokens/precompiled/PrecompiledContractsFactory.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/tokens/precompiled/PrecompiledContractsFactory.kt
@@ -16,13 +16,14 @@
 
 package io.exflo.ingestion.tokens.precompiled
 
+import io.exflo.ingestion.extensions.reflektField
 import io.exflo.ingestion.tokens.EVMFactory
-import java.math.BigInteger
-import java.util.NavigableSet
 import org.hyperledger.besu.ethereum.core.Account
 import org.hyperledger.besu.ethereum.mainnet.MutableProtocolSchedule
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec
+import java.math.BigInteger
+import java.util.NavigableSet
 
 /**
  * In order to use directly Solidity to detect several Token types (instead of relying directly with low level stuff)
@@ -38,13 +39,10 @@ object PrecompiledContractsFactory {
         check(protocolSchedule is MutableProtocolSchedule<*>) { "protocolSchedule must be of MutableProtocolSchedule" }
 
         // TODO: Review with Besu devs if there's a better way to avoid having reflection here
-        val protocolSpecsField = protocolSchedule::class.java.getDeclaredField("protocolSpecs")
-        protocolSpecsField.isAccessible = true
+        val protocolSpecs =
+            reflektField<NavigableSet<ScheduledProtocolSpec<*>>>(protocolSchedule, "protocolSpecs")
 
-        // Obtain registry of defined protocol specs
-        @Suppress("UNCHECKED_CAST") val protocolSpecs =
-            protocolSpecsField.get(protocolSchedule) as NavigableSet<ScheduledProtocolSpec<*>>
-
+        // TODO: MainnetEvmRegistries is also another useful class that shouldn't be private
         val evm = EVMFactory.istanbul(chainId)
 
         val erc20Detector = ERC20DetectorPrecompiledContract(evm)


### PR DESCRIPTION
# Description

We are resorting to reflection for now. In particular, we are not assuming the user is running Besu only for MAINNET or ROPSTEN networks as we are obtaining the current ProtocolSchedule being used.

Fixes #14 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

For now, manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules