### PR TITLE
fix: cli options namespace clash with custom rocksdb fix/rocksdb-plugin

### DIFF
--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloPlugin.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloPlugin.kt
@@ -57,9 +57,10 @@ abstract class ExfloPlugin<T : ExfloCliOptions> : BesuPlugin {
 
     private lateinit var besuCommand: BesuCommand
 
-    private val rocksDBPlugin = RocksDBPlugin()
+    private val rocksDBPlugin = ExfloRocksDBPlugin()
 
     override fun register(context: BesuContext) {
+
         rocksDBPlugin.register(context)
 
         log.debug("Registering plugin")

--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloRocksDBPlugin.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloRocksDBPlugin.kt
@@ -27,7 +27,6 @@ import org.hyperledger.besu.plugin.services.StorageService
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValuePrivacyStorageFactory
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValueStorageFactory
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory
-import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration
 import picocli.CommandLine

--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloRocksDBPlugin.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/ExfloRocksDBPlugin.kt
@@ -15,10 +15,10 @@
  */
 package io.exflo.ingestion
 
+import com.google.common.base.MoreObjects
 import com.google.common.base.Suppliers
 import io.exflo.ingestion.storage.InterceptingKeyValueStorageFactory
 import io.exflo.ingestion.storage.InterceptingPrivacyKeyValueStorageFactory
-import java.io.IOException
 import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.plugin.BesuContext
 import org.hyperledger.besu.plugin.BesuPlugin
@@ -28,6 +28,77 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValuePriva
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValueStorageFactory
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration
+import picocli.CommandLine
+import java.io.IOException
+
+internal class ExfloRocksDBCliOptions {
+
+    companion object {
+
+        private const val MAX_OPEN_FILES_FLAG = "--Xplugin-exflo-rocksdb-max-open-files"
+        private const val CACHE_CAPACITY_FLAG = "--Xplugin-exflo-rocksdb-cache-capacity"
+        private const val MAX_BACKGROUND_COMPACTIONS_FLAG = "--Xplugin-exflo-rocksdb-max-background-compactions"
+        private const val BACKGROUND_THREAD_COUNT_FLAG = "--Xplugin-exflo-rocksdb-background-thread-count"
+
+        fun fromConfig(config: RocksDBConfiguration): ExfloRocksDBCliOptions =
+            ExfloRocksDBCliOptions().apply {
+                this.maxOpenFiles = config.maxOpenFiles
+                this.cacheCapacity = config.cacheCapacity
+                this.maxBackgroundCompactions = config.maxBackgroundCompactions
+                this.backgroundThreadCount = config.backgroundThreadCount
+            }
+    }
+
+    @CommandLine.Option(
+        names = [MAX_OPEN_FILES_FLAG],
+        hidden = true,
+        defaultValue = "1024",
+        paramLabel = "<INTEGER>",
+        description = ["Max number of files RocksDB will open (default: \${DEFAULT-VALUE})"]
+    )
+    var maxOpenFiles = 0
+
+    @CommandLine.Option(
+        names = [CACHE_CAPACITY_FLAG],
+        hidden = true,
+        defaultValue = "8388608",
+        paramLabel = "<LONG>",
+        description = ["Cache capacity of RocksDB (default: \${DEFAULT-VALUE})"]
+    )
+    var cacheCapacity: Long = 0
+
+    @CommandLine.Option(
+        names = [MAX_BACKGROUND_COMPACTIONS_FLAG],
+        hidden = true,
+        defaultValue = "4",
+        paramLabel = "<INTEGER>",
+        description = ["Maximum number of RocksDB background compactions (default: \${DEFAULT-VALUE})"]
+    )
+    var maxBackgroundCompactions = 0
+
+    @CommandLine.Option(
+        names = [BACKGROUND_THREAD_COUNT_FLAG],
+        hidden = true,
+        defaultValue = "4",
+        paramLabel = "<INTEGER>",
+        description = ["Number of RocksDB background threads (default: \${DEFAULT-VALUE})"]
+    )
+    var backgroundThreadCount = 0
+
+    fun toDomainObject(): RocksDBFactoryConfiguration = RocksDBFactoryConfiguration(
+        maxOpenFiles, maxBackgroundCompactions, backgroundThreadCount, cacheCapacity
+    )
+
+    override fun toString(): String =
+        MoreObjects.toStringHelper(this)
+            .add("maxOpenFiles", maxOpenFiles)
+            .add("cacheCapacity", cacheCapacity)
+            .add("maxBackgroundCompactions", maxBackgroundCompactions)
+            .add("backgroundThreadCount", backgroundThreadCount)
+            .toString()
+}
 
 /**
  * This plugin intercepts calls made to [RocksDB] storage.
@@ -35,9 +106,9 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
  * The main difference between the original [RocksDbPlugin] and this one is on the construction of the factory where
  * we pass our custom [InterceptingKeyValueStorageFactory].
  */
-internal class RocksDBPlugin : BesuPlugin {
+internal class ExfloRocksDBPlugin : BesuPlugin {
 
-    private val options: RocksDBCLIOptions = RocksDBCLIOptions.create()
+    private val options: ExfloRocksDBCliOptions = ExfloRocksDBCliOptions()
 
     private var context: BesuContext? = null
     private var factory: InterceptingKeyValueStorageFactory? = null
@@ -118,6 +189,6 @@ internal class RocksDBPlugin : BesuPlugin {
     }
 
     companion object {
-        private const val NAME = "rocksdb"
+        private const val NAME = "exflo-rocksdb"
     }
 }


### PR DESCRIPTION
# Description

In order to gain access to the Blockchain data we override the default storage service with a
customised version of the rocksdb plugin that allows us to re-use the same underlying key/value
storage objects and get around the issues with creating a second instance of rocksdb backed by
the same files.

However the newer version of picocli throws an exception when an attempt is made to register the
same cli options. The fix was to create separately namespaced options.

The implications are that when using exflo user's will need to use our namespace rocksdb options
instead of the standard besu rocksdb cli options.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Locally running exflo and checking that it was writing to the db successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules