### PR TITLE
chore: removed assert not null to use instead check method

### DIFF
--- a/ingestion/base/src/main/kotlin/io/exflo/ingestion/extensions/ReflectExt.kt
+++ b/ingestion/base/src/main/kotlin/io/exflo/ingestion/extensions/ReflectExt.kt
@@ -16,16 +16,8 @@
 
 package io.exflo.ingestion.extensions
 
-fun <T : Any> assertNotNull(
-    actual: T?,
-    message: String = "null found"
-): T {
-    assert(actual != null) { message }
-    return actual!!
-}
-
 inline fun <reified T : Any> reflektField(entity: Any, fieldName: String): T {
-    val field = assertNotNull(entity::class.java.declaredFields.find { it.name == fieldName })
+    val field = checkNotNull(entity::class.java.declaredFields.find { it.name == fieldName })
     if (!field.canAccess(entity)) field.isAccessible = true
     return field.get(entity) as T
 }


### PR DESCRIPTION
# Description

This PR just removes `assertNotNull` method that I introduced without thinking that `check` was already there.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No need to test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules